### PR TITLE
Update start.sh for port number changes

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -9,7 +9,7 @@ if [[ -z "${MESOS_SLAVE_PID}" ]]; then
     source ~/.chs_env/global_env
     source ~/.chs_env/company-documents.web.ch.gov.uk/env
 
-    PORT="${COMPANY_DOCUMENTS_WEB_PORT:=10021}"
+    PORT="${COMPANY_DOCUMENTS_WEB_PORT}"
 else
     PORT="$1"
     CONFIG_URL="$2"


### PR DESCRIPTION
-The port number is defined in the global env file of chs_configs. 
Removing any manual port numbers from the start.sh file.